### PR TITLE
Fixed the return type of slidingWindowBy

### DIFF
--- a/src/bacon-extras.ts
+++ b/src/bacon-extras.ts
@@ -10,7 +10,7 @@ export type Observable<A> = Bacon.Observable<any, A>;
 
 export function slidingWindowBy<T>(
     observable: Observable<T>,
-    lengthObs: Observable<number>): Stream<T> {
+    lengthObs: Observable<number>): Stream<T[]> {
 
     return Bacon.fromBinder(sink => {
         let buf: T[] = [];


### PR DESCRIPTION
It collects the values of the observable and returns a collection of them. The types do not correctly specify this.